### PR TITLE
Move `CallRecord` instance out of `PhoneCallReceiver` to `CallRecordReceiver`

### DIFF
--- a/app/src/main/java/com/aykuttasil/callrecorder/MyCallRecordReceiver.java
+++ b/app/src/main/java/com/aykuttasil/callrecorder/MyCallRecordReceiver.java
@@ -1,7 +1,6 @@
 package com.aykuttasil.callrecorder;
 
 import android.content.Context;
-import android.util.Log;
 
 import com.aykuttasil.callrecord.CallRecord;
 import com.aykuttasil.callrecord.receiver.CallRecordReceiver;
@@ -19,10 +18,9 @@ public class MyCallRecordReceiver extends CallRecordReceiver {
     }
 
     @Override
-    protected void onOutgoingCallStarted(Context ctx, CallRecord callRecord, String number, Date start) {
-
+    protected void onOutgoingCallStarted(Context ctx, String number, Date start) {
         callRecord.disableSaveFile();
 
-        super.onOutgoingCallStarted(ctx, callRecord, number, start);
+        super.onOutgoingCallStarted(ctx, number, start);
     }
 }

--- a/callrecord/src/main/java/com/aykuttasil/callrecord/receiver/CallRecordReceiver.java
+++ b/callrecord/src/main/java/com/aykuttasil/callrecord/receiver/CallRecordReceiver.java
@@ -23,51 +23,50 @@ public class CallRecordReceiver extends PhoneCallReceiver {
     public static final String ACTION_OUT = "android.intent.action.NEW_OUTGOING_CALL";
     public static final String EXTRA_PHONE_NUMBER = "android.intent.extra.PHONE_NUMBER";
 
+    protected CallRecord callRecord;
     private static MediaRecorder recorder;
     private File audiofile;
     private boolean isRecordStarted = false;
 
-
     public CallRecordReceiver(CallRecord callRecord) {
-        super(callRecord);
+        this.callRecord = callRecord;
+    }
+
+    @Override
+    protected void onIncomingCallReceived(Context context, String number, Date start) {
 
     }
 
     @Override
-    protected void onIncomingCallReceived(Context ctx, CallRecord callRecord, String number, Date start) {
-
+    protected void onIncomingCallAnswered(Context context, String number, Date start) {
+        startRecord(context, "incoming", number);
     }
 
     @Override
-    protected void onIncomingCallAnswered(Context ctx, CallRecord callRecord, String number, Date start) {
-        startRecord(ctx, "incoming", number);
+    protected void onIncomingCallEnded(Context context, String number, Date start, Date end) {
+        stopRecord(context);
     }
 
     @Override
-    protected void onIncomingCallEnded(Context ctx, CallRecord callRecord, String number, Date start, Date end) {
-        stopRecord(ctx);
+    protected void onOutgoingCallStarted(Context context, String number, Date start) {
+        startRecord(context, "outgoing", number);
     }
 
     @Override
-    protected void onOutgoingCallStarted(Context ctx, CallRecord callRecord, String number, Date start) {
-        startRecord(ctx, "outgoing", number);
+    protected void onOutgoingCallEnded(Context context, String number, Date start, Date end) {
+        stopRecord(context);
     }
 
     @Override
-    protected void onOutgoingCallEnded(Context ctx, CallRecord callRecord, String number, Date start, Date end) {
-        stopRecord(ctx);
-    }
-
-    @Override
-    protected void onMissedCall(Context ctx, CallRecord callRecord, String number, Date start) {
+    protected void onMissedCall(Context context, String number, Date start) {
 
     }
 
     // Derived classes could override these to respond to specific events of interest
-    protected void onRecordingStarted(Context context, File audioFile) {
+    protected void onRecordingStarted(Context context, CallRecord callRecord, File audioFile) {
     }
 
-    protected void onRecordingFinished(Context context, File audioFile) {
+    protected void onRecordingFinished(Context context, CallRecord callRecord, File audioFile) {
     }
 
     private void startRecord(Context context, String seed, String phoneNumber) {
@@ -151,7 +150,7 @@ public class CallRecordReceiver extends PhoneCallReceiver {
             recorder.start();
 
             isRecordStarted = true;
-            onRecordingStarted(context, audiofile);
+            onRecordingStarted(context, callRecord, audiofile);
 
             Log.i(TAG, "record start");
 
@@ -168,7 +167,7 @@ public class CallRecordReceiver extends PhoneCallReceiver {
             recorder.release();
 
             isRecordStarted = false;
-            onRecordingFinished(context, audiofile);
+            onRecordingFinished(context, callRecord, audiofile);
 
             Log.i(TAG, "record stop");
         }

--- a/callrecord/src/main/java/com/aykuttasil/callrecord/receiver/PhoneCallReceiver.java
+++ b/callrecord/src/main/java/com/aykuttasil/callrecord/receiver/PhoneCallReceiver.java
@@ -5,8 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.telephony.TelephonyManager;
 
-import com.aykuttasil.callrecord.CallRecord;
-
 import java.util.Date;
 
 /**
@@ -21,11 +19,6 @@ public abstract class PhoneCallReceiver extends BroadcastReceiver {
     private static Date callStartTime;
     private static boolean isIncoming;
     private static String savedNumber;  //because the passed incoming is only valid in ringing
-    private CallRecord mCallRecord;
-
-    public PhoneCallReceiver(CallRecord callRecord) {
-        this.mCallRecord = callRecord;
-    }
 
     @Override
     public void onReceive(Context context, Intent intent) {
@@ -59,17 +52,17 @@ public abstract class PhoneCallReceiver extends BroadcastReceiver {
     }
 
     //Derived classes should override these to respond to specific events of interest
-    protected abstract void onIncomingCallReceived(Context ctx, CallRecord callRecord, String number, Date start);
+    protected abstract void onIncomingCallReceived(Context context, String number, Date start);
 
-    protected abstract void onIncomingCallAnswered(Context ctx, CallRecord callRecord, String number, Date start);
+    protected abstract void onIncomingCallAnswered(Context context, String number, Date start);
 
-    protected abstract void onIncomingCallEnded(Context ctx, CallRecord callRecord, String number, Date start, Date end);
+    protected abstract void onIncomingCallEnded(Context context, String number, Date start, Date end);
 
-    protected abstract void onOutgoingCallStarted(Context ctx, CallRecord callRecord, String number, Date start);
+    protected abstract void onOutgoingCallStarted(Context context, String number, Date start);
 
-    protected abstract void onOutgoingCallEnded(Context ctx, CallRecord callRecord, String number, Date start, Date end);
+    protected abstract void onOutgoingCallEnded(Context context, String number, Date start, Date end);
 
-    protected abstract void onMissedCall(Context ctx, CallRecord callRecord, String number, Date start);
+    protected abstract void onMissedCall(Context context, String number, Date start);
 
     //Deals with actual events
 
@@ -89,7 +82,7 @@ public abstract class PhoneCallReceiver extends BroadcastReceiver {
                 callStartTime = new Date();
                 savedNumber = number;
 
-                onIncomingCallReceived(context, mCallRecord, number, callStartTime);
+                onIncomingCallReceived(context, number, callStartTime);
 
                 break;
             case TelephonyManager.CALL_STATE_OFFHOOK:
@@ -99,14 +92,14 @@ public abstract class PhoneCallReceiver extends BroadcastReceiver {
                     isIncoming = false;
                     callStartTime = new Date();
 
-                    onOutgoingCallStarted(context, mCallRecord, savedNumber, callStartTime);
+                    onOutgoingCallStarted(context, savedNumber, callStartTime);
 
                 } else {
 
                     isIncoming = true;
                     callStartTime = new Date();
 
-                    onIncomingCallAnswered(context, mCallRecord, savedNumber, callStartTime);
+                    onIncomingCallAnswered(context, savedNumber, callStartTime);
 
                 }
 
@@ -117,16 +110,16 @@ public abstract class PhoneCallReceiver extends BroadcastReceiver {
                 if (lastState == TelephonyManager.CALL_STATE_RINGING) {
                     //Ring but no pickup-  a miss
 
-                    onMissedCall(context, mCallRecord, savedNumber, callStartTime);
+                    onMissedCall(context, savedNumber, callStartTime);
 
                 } else if (isIncoming) {
 
-                    onIncomingCallEnded(context, mCallRecord, savedNumber, callStartTime, new Date());
+                    onIncomingCallEnded(context, savedNumber, callStartTime, new Date());
 
                 } else {
 
-                    onOutgoingCallEnded(context, mCallRecord, savedNumber, callStartTime, new Date());
-                    
+                    onOutgoingCallEnded(context, savedNumber, callStartTime, new Date());
+
                 }
                 break;
         }


### PR DESCRIPTION
- `PhoneCallReceiver` abstract `SHOULD NOT` contains the instance of `CallRecord`, it just gives the way to listen the phone call state. We will do CallRecord businesses inside `CallRecordReceiver`